### PR TITLE
Added an 'ignore' option in bundle config

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -18,25 +18,27 @@ return static function (ContainerConfigurator $container) {
             param('kernel.project_dir'),
             abstract_arg('path to binary'),
             abstract_arg('embed sourcemap'),
+            abstract_arg('ignore list'),
         ])
         ->set('typescript.command.build', TypeScriptCompileCommand::class)
-        ->args([
-            service('typescript.builder')
-        ])
-        ->tag('console.command')
+            ->args([
+                service('typescript.builder')
+            ])
+            ->tag('console.command')
         ->set('typescript.js_asset_compiler', TypeScriptCompiler::class)
-        ->tag('asset_mapper.compiler', [
-            'priority' => 9
-        ])
-        ->args([
-            abstract_arg('path to typescript source dir'),
-            abstract_arg('path to typescript output directory'),
-            service('typescript.builder'),
-        ])
+            ->tag('asset_mapper.compiler', [
+                'priority' => 9
+            ])
+            ->args([
+                abstract_arg('path to typescript source dir'),
+                abstract_arg('path to typescript output directory'),
+                service('typescript.builder'),
+                abstract_arg('ignore list'),
+            ])
         ->set('typescript.public_asset_path_resolver', TypeScriptPublicPathAssetPathResolver::class)
-        ->decorate('asset_mapper.public_assets_path_resolver')
-        ->args([
-            service('.inner')
-        ]);
+            ->decorate('asset_mapper.public_assets_path_resolver')
+            ->args([
+                service('.inner')
+            ]);
 ;
 };

--- a/src/AssetMapper/TypeScriptCompiler.php
+++ b/src/AssetMapper/TypeScriptCompiler.php
@@ -22,6 +22,7 @@ class TypeScriptCompiler implements AssetCompilerInterface
         private readonly array $typeScriptFilesPaths,
         private readonly string $jsPathDirectory,
         private readonly string $projectRootDir,
+        private readonly array $ignoredPaths = [],
     )
     {
         $this->fileSystem = new Filesystem();
@@ -30,6 +31,9 @@ class TypeScriptCompiler implements AssetCompilerInterface
     public function supports(MappedAsset $asset): bool
     {
         if (!str_ends_with($asset->sourcePath, '.ts')) {
+            return false;
+        }
+        if (in_array($asset->sourcePath, $this->ignoredPaths, true)) {
             return false;
         }
         foreach ($this->typeScriptFilesPaths as $path) {

--- a/src/DependencyInjection/SensiolabsTypescriptExtension.php
+++ b/src/DependencyInjection/SensiolabsTypescriptExtension.php
@@ -29,12 +29,14 @@ class SensiolabsTypescriptExtension extends Extension implements ConfigurationIn
             ->replaceArgument(0, $config['source_dir'])
             ->replaceArgument(1, '%kernel.project_dir%/var/compiled_js')
             ->replaceArgument(3, $config['binary'])
-            ->replaceArgument(4, $config['embed_sourcemap']);
+            ->replaceArgument(4, $config['embed_sourcemap'])
+            ->replaceArgument(5, $config['ignore']);
 
         $container->findDefinition('typescript.js_asset_compiler')
             ->replaceArgument(0, $config['source_dir'])
             ->replaceArgument(1, '%kernel.project_dir%/var/compiled_js')
-            ->replaceArgument(2, '%kernel.project_dir%');
+            ->replaceArgument(2, '%kernel.project_dir%')
+            ->replaceArgument(3, $config['ignore']);
     }
 
     public function getConfiguration(array $config, ContainerBuilder $container): ?ConfigurationInterface
@@ -52,20 +54,26 @@ class SensiolabsTypescriptExtension extends Extension implements ConfigurationIn
         $rootNode
             ->children()
                 ->arrayNode('source_dir')
-                    ->info('Path to your TypeScript directories')
+                    ->info('List of paths (files or directories) to your TypeScript directories')
                     ->cannotBeEmpty()
                     ->scalarPrototype()
                         ->end()
                     ->defaultValue(['%kernel.project_dir%/assets/typescript'])
-                ->end()
-                    ->scalarNode('binary')
+                    ->end()
+                ->scalarNode('binary')
                     ->info('The TypeScript compiler binary to use')
                     ->defaultNull()
-                ->end()
-                    ->scalarNode('embed_sourcemap')
+                    ->end()
+                ->scalarNode('embed_sourcemap')
                     ->info('Whether to embed the sourcemap in the compiled CSS. By default, enabled only when debug mode is on.')
                     ->defaultValue($this->isDebug)
-                ->end()
+                    ->end()
+                ->arrayNode('ignore')
+                    ->info('List of paths (files or directories) to exclude from compilation and asset mapping.')
+                    ->scalarPrototype()
+                        ->end()
+                    ->defaultValue([])
+                    ->end()
             ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
Closes #1 

This is a tricky one. SWC has [an '--ignore' option](https://swc.rs/docs/usage/cli#--ignore), but it allows only a single path to be excluded (or at least I didn't manage to make it take multiple paths.)
So the solution I found was to pass a config snippet with `--config-json` (not documented on there website) to override the "exclude" config from `.swcrc`. This works, but SWC prints an error and exits with a `1` return code, so I had to disable printing the output of the command (which didn't print anything anyway) and apply a test on the error message to check if it's a 'real' error or just a notification that a file has been skipped.

Right now I think it's a very dirty hack, and I don't see any other solution  but to ask the swc repo to be able to bypass this