### PR TITLE
Fixed tests when original content === compiled

### DIFF
--- a/tests/FunctionalTest.php
+++ b/tests/FunctionalTest.php
@@ -18,20 +18,21 @@ class FunctionalTest extends KernelTestCase
 {
     protected function setUp(): void
     {
-        file_put_contents(__DIR__.'/fixtures/assets/typescript/main.js', <<<EOF
-            console.log('Hello world');
+        $filesystem = new Filesystem();
+        $filesystem->mkdir(__DIR__.'/fixtures/var');
+        $filesystem->dumpFile(__DIR__.'/fixtures/var/typescript/assets/typescript/main.js', <<<EOF
+            var greeting = "Hello, World!";
+            console.log(greeting);
             EOF
         );
-
-        if (file_exists(__DIR__.'/fixtures/var')) {
-            $filesystem = new Filesystem();
-            $filesystem->remove(__DIR__.'/fixtures/var');
-        }
     }
 
     protected function tearDown(): void
     {
-        unlink(__DIR__.'/fixtures/assets/typescript/main.js');
+        $filesystem = new Filesystem();
+        if (file_exists(__DIR__.'/fixtures/var')) {
+            $filesystem->remove(__DIR__.'/fixtures/var');
+        }
     }
 
     public function testBuildJsIfUsed(): void
@@ -41,8 +42,11 @@ class FunctionalTest extends KernelTestCase
         $assetMapper = self::getContainer()->get('asset_mapper');
         \assert($assetMapper instanceof AssetMapperInterface);
 
-        $asset = $assetMapper->getAsset('typescript/main.js');
+        $asset = $assetMapper->getAsset('typescript/main.ts');
         $this->assertInstanceOf(MappedAsset::class, $asset);
-        $this->assertStringContainsString('console.log(\'Hello world\');', $asset->content);
+        $this->assertStringContainsString(<<<EOF
+            var greeting = "Hello, World!";
+            console.log(greeting);
+            EOF, $asset->content);
     }
 }

--- a/tests/fixtures/assets/typescript/main.ts
+++ b/tests/fixtures/assets/typescript/main.ts
@@ -1,6 +1,2 @@
-import {CustomModule} from './dir/custom.module.ts';
-import {Toast} from 'bootstrap';
-CustomModule.printMessage();
-
-let toast = new Toast(document.querySelector('.toast'));
-toast.show();
+const greeting: string = "Hello, World!";
+console.log(greeting);


### PR DESCRIPTION
Fixes tests on SF 6.4 and 7.0 that broke when original content is identical to compiled content. This behavior was introduced in https://github.com/symfony/symfony/blob/78ec570236cd0f696dbc6e3932dc937bb4e47493/src/Symfony/Component/AssetMapper/Factory/MappedAssetFactory.php#L109