### PR TITLE
Fixed watch option not working on files in subfolders

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -1,5 +1,5 @@
 <?php
-//
+
 use Sensiolabs\TypeScriptBundle\AssetMapper\TypeScriptCompiler;
 use Sensiolabs\TypeScriptBundle\AssetMapper\TypeScriptPublicPathAssetPathResolver;
 use Sensiolabs\TypeScriptBundle\Command\TypeScriptBuildCommand;
@@ -7,9 +7,10 @@ use Sensiolabs\TypeScriptBundle\EventListener\PreAssetsCompileListener;
 use Sensiolabs\TypeScriptBundle\TypeScriptBuilder;
 use Symfony\Component\AssetMapper\Event\PreAssetsCompileEvent;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
 use function Symfony\Component\DependencyInjection\Loader\Configurator\abstract_arg;
-use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -20,7 +21,6 @@ return static function (ContainerConfigurator $container) {
                 param('kernel.project_dir'),
                 abstract_arg('path to the binaries download directory'),
                 abstract_arg('path to the swc binary'),
-                abstract_arg('path to the watchexec binary'),
             ])
         ->set('sensiolabs_typescript.command.build', TypeScriptBuildCommand::class)
             ->args([

--- a/src/DependencyInjection/SensiolabsTypeScriptExtension.php
+++ b/src/DependencyInjection/SensiolabsTypeScriptExtension.php
@@ -30,8 +30,7 @@ class SensiolabsTypeScriptExtension extends Extension implements ConfigurationIn
             ->replaceArgument(1, '%kernel.project_dir%/var/typescript')
             ->replaceArgument(3, $config['binary_download_dir'])
             ->replaceArgument(4, $config['swc_binary'])
-            ->replaceArgument(5, $config['watchexec_binary']);
-
+        ;
         $container->findDefinition('sensiolabs_typescript.js_asset_compiler')
             ->replaceArgument(0, $config['source_dir'])
             ->replaceArgument(1, '%kernel.project_dir%/var/typescript')

--- a/src/Tools/WatcherBinary.php
+++ b/src/Tools/WatcherBinary.php
@@ -16,6 +16,9 @@ class WatcherBinary
      */
     public function startWatch(string $watchPath, callable $callback, array $extensions = []): Process
     {
+        if (!str_ends_with($watchPath, \DIRECTORY_SEPARATOR.'...')) {
+            $watchPath = rtrim($watchPath, \DIRECTORY_SEPARATOR).\DIRECTORY_SEPARATOR.'...';
+        }
         $process = new Process([$this->executablePath, $watchPath]);
 
         $process->start(function ($type, $buffer) use ($callback, $extensions) {

--- a/src/TypeScriptBuilder.php
+++ b/src/TypeScriptBuilder.php
@@ -22,7 +22,6 @@ class TypeScriptBuilder
         private readonly string $projectRootDir,
         private readonly string $binaryDownloadDir,
         private readonly ?string $buildBinaryPath,
-        private readonly ?string $watchexecBinaryPath,
     ) {
     }
 
@@ -58,31 +57,6 @@ class TypeScriptBuilder
         }
 
         return $this->getWatchexecBinary()->startWatch($relativePath, fn ($path, $operation) => $this->createBuildProcess($path), ['ts']);
-        //
-        //        $watchProcess = $this->getWatchexecBinary()->createProcess($relativePath);
-        //        $watchProcess->setTimeout(null)->setIdleTimeout(null);
-        //        $this->output?->note(sprintf('Watching for changes in %s...', $relativePath));
-        //        if ($this->output?->isVerbose()) {
-        //            $this->output->writeln([
-        //                '  Command:',
-        //                '    '.$watchProcess->getCommandLine(),
-        //            ]);
-        //        }
-        //        $watchProcess->start(function ($type, $buffer) {
-        //            if ('err' === $type) {
-        //                throw new \RuntimeException($buffer);
-        //            }
-        //            $path = trim($buffer);
-        //            if ('/' === $path) {
-        //                return;
-        //            }
-        //            $newProcess = $this->createBuildProcess($path);
-        //            $newProcess->wait(function ($type, $buffer) {
-        //                $this->output?->write($buffer);
-        //            });
-        //        });
-        //
-        //        return $watchProcess;
     }
 
     public function setOutput(SymfonyStyle $output): void

--- a/tests/Tools/WatcherBinaryFactoryTest.php
+++ b/tests/Tools/WatcherBinaryFactoryTest.php
@@ -15,7 +15,7 @@ class WatcherBinaryFactoryTest extends TestCase
         // Test that the binary exists and the process is created with the correct arguments
         $binary = (new WatcherBinaryFactory())->getBinaryFromServerSpecs('Linux');
         $process = $binary->startWatch($this->watchPath, fn ($path, $operation) => '');
-        $this->assertEquals('\''.realpath($this->binaryDir).'/watcher-linux\' \''.$this->watchPath.'\'', $process->getCommandLine());
+        $this->assertEquals('\''.realpath($this->binaryDir).'/watcher-linux\' \''.$this->watchPath.'/...\'', $process->getCommandLine());
 
         // Test that an exception is thrown when the platform is not supported
         $this->expectException(\Exception::class);


### PR DESCRIPTION
The watch option wasn't catching change events from files nested in sub folders. This PR fixes this by appending `'/...'` to the folder path (it seems that's how the go `notify` package works) + removes commented code (how did that make it to the main branch ? :sob: ) and an unused property.

