### PR TITLE
Fix windows binary resolution

### DIFF
--- a/src/Tools/TypescriptBinaryFactory.php
+++ b/src/Tools/TypescriptBinaryFactory.php
@@ -80,14 +80,14 @@ class TypescriptBinaryFactory
         }
 
         if (str_contains($os, 'win')) {
-            if ('x86_64' === $machine) {
-                return 'swc-win32-x64-msvc';
+            if ('x86_64' === $machine || 'amd64' === $machine) {
+                return 'swc-win32-x64-msvc.exe';
             }
-            if ('amd64' === $machine) {
-                return 'swc-win32-arm64-msvc';
+            if ('arm64' === $machine) {
+                return 'swc-win32-arm64-msvc.exe';
             }
             if ('i586' === $machine) {
-                return 'swc-win32-ia32-msvc';
+                return 'swc-win32-ia32-msvc.exe';
             }
 
             throw new \Exception(sprintf('No matching machine found for Windows platform (Machine: %s).', $machine));

--- a/tests/Tools/TypeScriptBinaryFactoryTest.php
+++ b/tests/Tools/TypeScriptBinaryFactoryTest.php
@@ -66,9 +66,10 @@ class TypeScriptBinaryFactoryTest extends TestCase
             ['Linux', 'x86_64', 'linux-musl', 'swc-linux-x64-musl'],
             ['Linux', 'arm64', 'linux-musl', 'swc-linux-arm64-musl'],
 
-            ['Windows', 'x86_64', 'windows', 'swc-win32-x64-msvc'],
-            ['Windows', 'amd64', 'windows', 'swc-win32-arm64-msvc'],
-            ['Windows', 'i586', 'windows', 'swc-win32-ia32-msvc'],
+            ['Windows', 'x86_64', 'windows', 'swc-win32-x64-msvc.exe'],
+            ['Windows', 'amd64', 'windows', 'swc-win32-x64-msvc.exe'],
+            ['Windows', 'arm64', 'windows', 'swc-win32-arm64-msvc.exe'],
+            ['Windows', 'i586', 'windows', 'swc-win32-ia32-msvc.exe'],
 
             ['Undefined', 'x86_64', 'darwin', null, \Exception::class],
             ['Darwin', 'undefined', 'darwin', null, \Exception::class],


### PR DESCRIPTION
While testing the bundle on windows I notices a problem with the swc binary resolution. This PR fixes this (at least for AMD64) and deletes an old watchexec test binary)