### PR TITLE
Renamed 'TypescriptBinaryFactory' to 'TypeScriptBinaryFactory'

### DIFF
--- a/src/Tools/TypeScriptBinaryFactory.php
+++ b/src/Tools/TypeScriptBinaryFactory.php
@@ -7,7 +7,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
-class TypescriptBinaryFactory
+class TypeScriptBinaryFactory
 {
     private const VERSION = 'v1.3.92';
     private const SWC_RELEASE_URL_PATTERN = 'https://github.com/swc-project/swc/releases/download/%s/%s';

--- a/src/TypeScriptBuilder.php
+++ b/src/TypeScriptBuilder.php
@@ -3,7 +3,7 @@
 namespace Sensiolabs\TypeScriptBundle;
 
 use Sensiolabs\TypeScriptBundle\Tools\TypeScriptBinary;
-use Sensiolabs\TypeScriptBundle\Tools\TypescriptBinaryFactory;
+use Sensiolabs\TypeScriptBundle\Tools\TypeScriptBinaryFactory;
 use Sensiolabs\TypeScriptBundle\Tools\WatcherBinary;
 use Sensiolabs\TypeScriptBundle\Tools\WatcherBinaryFactory;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -69,7 +69,7 @@ class TypeScriptBuilder
         if ($this->buildBinary) {
             return $this->buildBinary;
         }
-        $typescriptBinaryFactory = new TypescriptBinaryFactory($this->binaryDownloadDir);
+        $typescriptBinaryFactory = new TypeScriptBinaryFactory($this->binaryDownloadDir);
         $typescriptBinaryFactory->setOutput($this->output);
 
         return $this->buildBinary = $this->buildBinaryPath ?

--- a/tests/Tools/TypeScriptBinaryFactoryTest.php
+++ b/tests/Tools/TypeScriptBinaryFactoryTest.php
@@ -3,7 +3,7 @@
 namespace Sensiolabs\TypeScriptBundle\Tests\Tools;
 
 use PHPUnit\Framework\TestCase;
-use Sensiolabs\TypeScriptBundle\Tools\TypescriptBinaryFactory;
+use Sensiolabs\TypeScriptBundle\Tools\TypeScriptBinaryFactory;
 
 class TypeScriptBinaryFactoryTest extends TestCase
 {
@@ -51,7 +51,7 @@ class TypeScriptBinaryFactoryTest extends TestCase
             $this->expectException($exception);
         }
 
-        $this->assertEquals($expectedBinaryName, TypescriptBinaryFactory::getBinaryNameFromServerSpecs($os, $machine, $kernel));
+        $this->assertEquals($expectedBinaryName, TypeScriptBinaryFactory::getBinaryNameFromServerSpecs($os, $machine, $kernel));
     }
 
     public function provideServerSpecs()


### PR DESCRIPTION
Fixed typo in TypeScriptBinaryFactory class name