### PR TITLE
symfony 7 documentation

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -42,6 +42,16 @@ Then load your TypeScript files in your templates:
         <script type="text/javascript" src="{{ asset('typescript/app.ts') }}"></script>
     {% endblock %}
 
+For Symfony 7: 
+
+.. code-block:: html+twig
+
+    {# templates/base.html.twig #}
+
+    {% block javascripts %}
+       {{ importmap('typescript/app') }}
+    {% endblock %}
+     
 Finally run this command:
 
 .. code-block:: terminal


### PR DESCRIPTION
In Symfony 7 doesnt working default asset function: 
   <script type="text/javascript" src="{{ asset('typescript/app.ts') }}"></script>  

I solved it with: 
{{ importmap('typescript/app') }}