### PR TITLE
Fix binary file permissions

### DIFF
--- a/src/Tools/TypeScriptBinaryFactory.php
+++ b/src/Tools/TypeScriptBinaryFactory.php
@@ -138,6 +138,6 @@ class TypeScriptBinaryFactory
         $progressBar?->finish();
         $this->output->writeln('');
 
-        chmod($this->binaryDownloadDir.'/'.$binaryName, 7770);
+        chmod($this->binaryDownloadDir.'/'.$binaryName, 0777);
     }
 }


### PR DESCRIPTION
This PR resolves an issue where the binary file permissions were not being set correctly.

0777 results in the desired permissions:
-rwxrwxrwx

7770 results in:
---s-ws-wT
