### PR TITLE
Allow specifying SWC version

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -22,6 +22,7 @@ return static function (ContainerConfigurator $container) {
                 abstract_arg('path to the binaries download directory'),
                 abstract_arg('path to the swc binary'),
                 abstract_arg('swc configuration file'),
+                abstract_arg('swc version'),
             ])
         ->set('sensiolabs_typescript.command.build', TypeScriptBuildCommand::class)
             ->args([

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -110,6 +110,17 @@ that binary with the ``swc_binary`` option:
     sensiolabs_typescript:
         swc_binary: 'node_modules/.bin/swc'
 
+By default, the bundle uses SWC v1.3.92. However, you can specify a different
+SWC version to compile your codebase if you need a newer feature or bug fix:
+
+.. code-block:: yaml
+
+    # config/packages/asset_mapper.yaml
+    sensiolabs_typescript:
+        swc_version: v1.7.27-nightly-20240911.1
+
+Note that you should remove the existing SWC binary in the `var` directory after switching the `swc_version`; otherwise, it will use the old binary.
+
 Configuring the compiler
 ------------------------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -115,11 +115,11 @@ SWC version to compile your codebase if you need a newer feature or bug fix:
 
 .. code-block:: yaml
 
-    # config/packages/asset_mapper.yaml
+    # config/packages/sensiolabs_typescript.yaml
     sensiolabs_typescript:
         swc_version: v1.7.27-nightly-20240911.1
 
-Note that you should remove the existing SWC binary in the `var` directory after switching the `swc_version`; otherwise, it will use the old binary.
+Note that you should remove the existing SWC binary in the download directory (``var`` by default) after switching the ``swc_version``; the download is only triggered if no binary is found in the download directory. Otherwise, the existing binary will still be used.
 
 Configuring the compiler
 ------------------------

--- a/src/DependencyInjection/SensiolabsTypeScriptExtension.php
+++ b/src/DependencyInjection/SensiolabsTypeScriptExtension.php
@@ -31,6 +31,7 @@ class SensiolabsTypeScriptExtension extends Extension implements ConfigurationIn
             ->replaceArgument(3, $config['binary_download_dir'])
             ->replaceArgument(4, $config['swc_binary'])
             ->replaceArgument(5, $config['swc_config_file'])
+            ->replaceArgument(6, $config['swc_version'])
         ;
         $container->findDefinition('sensiolabs_typescript.js_asset_compiler')
             ->replaceArgument(0, $config['source_dir'])
@@ -74,6 +75,10 @@ class SensiolabsTypeScriptExtension extends Extension implements ConfigurationIn
                 ->scalarNode('swc_config_file')
                     ->info('Path to .swcrc configuration file to use')
                     ->defaultValue('%kernel.project_dir%/.swcrc')
+                ->end()
+                ->scalarNode('swc_version')
+                    ->info('The SWC version to use')
+                    ->defaultValue('v1.3.92')
                 ->end()
             ->end()
         ;

--- a/src/Tools/TypeScriptBinaryFactory.php
+++ b/src/Tools/TypeScriptBinaryFactory.php
@@ -8,13 +8,13 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class TypeScriptBinaryFactory
 {
-    private const VERSION = 'v1.3.92';
     private const SWC_RELEASE_URL_PATTERN = 'https://github.com/swc-project/swc/releases/download/%s/%s';
     private HttpClientInterface $httpClient;
     private SymfonyStyle $output;
 
     public function __construct(
         private readonly string $binaryDownloadDir,
+        private readonly string $swcVersion,
         ?HttpClientInterface $httpClient = null,
     ) {
         $this->httpClient = $httpClient ?? HttpClient::create();
@@ -105,7 +105,7 @@ class TypeScriptBinaryFactory
         if (file_exists($targetPath)) {
             return;
         }
-        $url = \sprintf(self::SWC_RELEASE_URL_PATTERN, self::VERSION, $binaryName);
+        $url = \sprintf(self::SWC_RELEASE_URL_PATTERN, $this->swcVersion, $binaryName);
 
         if ($this->output->isVerbose()) {
             $this->output->note(\sprintf('Downloading SWC binary from "%s" to "%s"...', $url, $targetPath));

--- a/src/Tools/TypeScriptBinaryFactory.php
+++ b/src/Tools/TypeScriptBinaryFactory.php
@@ -126,6 +126,15 @@ class TypeScriptBinaryFactory
                 $progressBar->setProgress($dlNow);
             },
         ]);
+
+        if (200 !== $statusCode = $response->getStatusCode()) {
+            $exceptionMessage = \sprintf('Could not download SWC binary from "%s" (request responded with %d).', $url, $statusCode);
+            if (404 === $statusCode) {
+                $exceptionMessage .= PHP_EOL.\sprintf('Check that the version "%s" defined in "sensiolabs_typescript.swc_version" exists.', $this->swcVersion);
+            }
+            throw new \Exception($exceptionMessage);
+        }
+
         $fileHandler = fopen($targetPath, 'w');
         if (false === $fileHandler) {
             throw new \Exception(\sprintf('Could not open file "%s" for writing.', $targetPath));

--- a/src/TypeScriptBuilder.php
+++ b/src/TypeScriptBuilder.php
@@ -77,7 +77,7 @@ class TypeScriptBuilder
         if ($this->buildBinary) {
             return $this->buildBinary;
         }
-        $typescriptBinaryFactory = new TypeScriptBinaryFactory($this->binaryDownloadDir);
+        $typescriptBinaryFactory = new TypeScriptBinaryFactory($this->binaryDownloadDir, $this->swcVersion);
         $typescriptBinaryFactory->setOutput($this->output);
 
         return $this->buildBinary = $this->buildBinaryPath ?

--- a/src/TypeScriptBuilder.php
+++ b/src/TypeScriptBuilder.php
@@ -26,6 +26,7 @@ class TypeScriptBuilder
         private readonly string $binaryDownloadDir,
         private readonly ?string $buildBinaryPath,
         private readonly ?string $configFile,
+        private readonly string $swcVersion,
     ) {
     }
 

--- a/tests/Tools/TypeScriptBinaryFactoryTest.php
+++ b/tests/Tools/TypeScriptBinaryFactoryTest.php
@@ -13,6 +13,7 @@ class TypeScriptBinaryFactoryTest extends TestCase
     {
         return new TypeScriptBinaryFactory(
             $this->binaryDownloadDir,
+            'v1.3.92'
         );
     }
 


### PR DESCRIPTION
Fix #53.

* Allow specifying the `swc_version` in the configuration YAML file.
* The downloaded binary name will contain the SWC version users picked.
* Docs and tests are added.

By default, it uses the (current) latest SWC version v1.7.26:

```
$ php ./bin/console typescript:build -v

 ! [NOTE] Downloading SWC binary from "https://github.com/swc-project/swc/releases/download/v1.7.26/swc-darwin-arm64" to
 !        "/Volumes/Dev/ResearchProject/lets-php/app-sf/var/swc-v1.7.26-darwin-arm64"...                                

 34787224/34787224 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%  1 sec
 ! [NOTE] Executing SWC compile on assets.                                                                              

  Command:
    '/Volumes/Dev/ResearchProject/lets-php/app-sf/var/swc-v1.7.26-darwin-arm64' 'compile' 'assets' '--out-dir' '/Volumes/Dev/ResearchProject/lets-php/app-sf/var/typescript' '--config-file' '.swcrc'
```

Users can specify it in `config`:

```yaml
sensiolabs_typescript:
  swc_version: v1.7.27-nightly-20240911.1
```

and AssetMapperTypeScriptBundle will download and use the user-picked version.

```
$ php ./bin/console typescript:build -v

 ! [NOTE] Downloading SWC binary from "https://github.com/swc-project/swc/releases/download/v1.7.27-nightly-20240911.1/swc-darwin-arm64" to
 !        "/Volumes/Dev/ResearchProject/lets-php/app-sf/var/swc-v1.7.27-nightly-20240911.1-darwin-arm64"...             

 34787224/34787224 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100% 3 secs
 ! [NOTE] Executing SWC compile on assets.                                                                              

  Command:
    '/Volumes/Dev/ResearchProject/lets-php/app-sf/var/swc-v1.7.27-nightly-20240911.1-darwin-arm64' 'compile' 'assets' '--out-dir' '/Volumes/Dev/ResearchProject/lets-php/app-sf/var/typescript' '--config-file' '.swcrc'
```

Of course, the downloaded binary is still cached.

```
$ php ./bin/console typescript:build -v

 ! [NOTE] Executing SWC compile on assets.                                                                              

  Command:
    '/Volumes/Dev/ResearchProject/lets-php/app-sf/var/swc-v1.7.27-nightly-20240911.1-darwin-arm64' 'compile' 'assets' '--out-dir' '/Volumes/Dev/ResearchProject/lets-php/app-sf/var/typescript' '--config-file' '.swcrc'
```

![CleanShot 2024-09-17 at 17 22 15@2x](https://github.com/user-attachments/assets/a1e86df6-f88f-4f00-9da5-2f89c77ea911)
