### PR TITLE
feat: allow configuring the compile directory

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -37,7 +37,7 @@ return static function (ContainerConfigurator $container) {
             ->args([
                 abstract_arg('path to typescript source dir'),
                 abstract_arg('path to typescript output directory'),
-                service('sensiolabs_typescript.builder'),
+                abstract_arg('path to project root directory'),
             ])
         ->set('sensiolabs_typescript.public_asset_path_resolver', TypeScriptPublicPathAssetPathResolver::class)
             ->decorate('asset_mapper.public_assets_path_resolver')

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,9 +81,9 @@ The first time you run one of the TypeScript commands, the bundle will download
 the correct SWC binary for your system into the ``var/`` directory.
 
 When you run ``typescript:build``, that binary is used to compile TypeScript files
-into a ``var/typescript/`` directory. Finally, when the contents of ``assets/typescript/app.ts``
-is requested, the bundle swaps the contents of that file with the contents of
-the ``var/typescript/`` directory.
+into the ``compile_dir`` (default: ``%kernel.project_dir%/var/typescript``) directory. Finally, when the contents of
+``assets/typescript/app.ts`` is requested, the bundle swaps the contents of that file with the contents of
+the ``compile_dir`` directory.
 
 Configuration
 -------------

--- a/src/DependencyInjection/SensiolabsTypeScriptExtension.php
+++ b/src/DependencyInjection/SensiolabsTypeScriptExtension.php
@@ -27,7 +27,7 @@ class SensiolabsTypeScriptExtension extends Extension implements ConfigurationIn
 
         $container->findDefinition('sensiolabs_typescript.builder')
             ->replaceArgument(0, $config['source_dir'])
-            ->replaceArgument(1, '%kernel.project_dir%/var/typescript')
+            ->replaceArgument(1, $config['compile_dir'])
             ->replaceArgument(3, $config['binary_download_dir'])
             ->replaceArgument(4, $config['swc_binary'])
             ->replaceArgument(5, $config['swc_config_file'])
@@ -35,7 +35,7 @@ class SensiolabsTypeScriptExtension extends Extension implements ConfigurationIn
         ;
         $container->findDefinition('sensiolabs_typescript.js_asset_compiler')
             ->replaceArgument(0, $config['source_dir'])
-            ->replaceArgument(1, '%kernel.project_dir%/var/typescript')
+            ->replaceArgument(1, $config['compile_dir'])
             ->replaceArgument(2, '%kernel.project_dir%')
         ;
     }
@@ -67,6 +67,10 @@ class SensiolabsTypeScriptExtension extends Extension implements ConfigurationIn
                 ->scalarNode('binary_download_dir')
                     ->info('The directory where the SWC binary will be downloaded')
                     ->defaultValue('%kernel.project_dir%/var')
+                ->end()
+                ->scalarNode('compile_dir')
+                    ->info('The directory where the compiled JavaScript files will be stored')
+                    ->defaultValue('%kernel.project_dir%/var/typescript')
                 ->end()
                 ->scalarNode('swc_binary')
                     ->info('The SWC binary to use')


### PR DESCRIPTION
I just realized this path wasn't configurable. This might be useful in deployment processes.

I also noticed that the `js_asset_compiler` definition wasn't right (3rd argument defaulted to `sensiolabs_typescript.builder` service, though was replaced by the project dir. This is now fixed.