### PR TITLE
chore: move tool dependencies to a tool directory + fix violation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,9 @@ jobs:
           php-version: 8.5
 
       - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Install PHP-CS-Fixer dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader --working-dir=tools/php-cs-fixer
 
       - name: Run PHP-CS-Fixer
@@ -98,6 +101,9 @@ jobs:
           php-version: 8.5
 
       - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Install PHPStan dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader --working-dir=tools/phpstan
 
       - name: Run PHPStan

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,12 +77,13 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
-          tools: php-cs-fixer
+          php-version: 8.5
+
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader --working-dir=tools/php-cs-fixer
 
       - name: Run PHP-CS-Fixer
-        run:
-          php-cs-fixer fix --dry-run --diff
+        run: tools/php-cs-fixer/vendor/bin/php-cs-fixer fix --diff --dry-run
 
   phpstan:
     name: PHPStan
@@ -94,11 +95,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
-          tools: phpstan
+          php-version: 8.5
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader
+        run: composer install --no-progress --prefer-dist --optimize-autoloader --working-dir=tools/phpstan
 
       - name: Run PHPStan
-        run: vendor/bin/phpstan analyse
+        run: tools/phpstan/vendor/bin/phpstan analyse

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,6 @@
     "require-dev": {
         "symfony/filesystem": "^6.3|^7.0|^8.0",
         "symfony/framework-bundle": "^6.3|^7.0|^8.0",
-        "phpstan/phpstan": "^1",
-        "phpstan/phpstan-symfony": "^1.3",
         "phpunit/phpunit": "^10.5"
     },
     "autoload": {
@@ -34,5 +32,19 @@
         "psr-4": {
             "Sensiolabs\\TypeScriptBundle\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "tools:upgrade": [
+            "@tools:upgrade:php-cs-fixer",
+            "@tools:upgrade:phpstan"
+        ],
+        "tools:upgrade:php-cs-fixer": "composer upgrade -W -d tools/php-cs-fixer",
+        "tools:upgrade:phpstan": "composer upgrade -W -d tools/phpstan",
+        "tools:run": [
+            "@tools:run:php-cs-fixer",
+            "@tools:run:phpstan"
+        ],
+        "tools:run:php-cs-fixer": "tools/php-cs-fixer/vendor/bin/php-cs-fixer fix",
+        "tools:run:phpstan": "tools/phpstan/vendor/bin/phpstan --memory-limit=1G"
     }
 }

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -4,4 +4,4 @@ parameters:
         - src/
         - tests/
 includes:
-    - vendor/phpstan/phpstan-symfony/extension.neon
+    - tools/phpstan/vendor/phpstan/phpstan-symfony/extension.neon

--- a/src/DependencyInjection/SensiolabsTypeScriptExtension.php
+++ b/src/DependencyInjection/SensiolabsTypeScriptExtension.php
@@ -2,7 +2,6 @@
 
 namespace Sensiolabs\TypeScriptBundle\DependencyInjection;
 
-use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
@@ -48,12 +47,14 @@ class SensiolabsTypeScriptExtension extends Extension implements ConfigurationIn
         return $this;
     }
 
+    /**
+     * @return TreeBuilder<'array'>
+     */
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('sensiolabs_typescript');
 
         $rootNode = $treeBuilder->getRootNode();
-        \assert($rootNode instanceof ArrayNodeDefinition);
 
         $rootNode
             ->children()

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,2 @@
+**/vendor
+**/composer.lock

--- a/tools/php-cs-fixer/composer.json
+++ b/tools/php-cs-fixer/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "friendsofphp/php-cs-fixer": "^3"
+  }
+}

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,0 +1,6 @@
+{
+  "require": {
+    "phpstan/phpstan": "^2",
+    "phpstan/phpstan-symfony": "^2"
+  }
+}


### PR DESCRIPTION
A Phpstan violation popped recently, so I took this opportunity to upgrade phpstan to version 2, and move it to a dedicated `tools` directory with a dedicated `composer.json`. 
I also added php-cs-fixer with minimal config.